### PR TITLE
Fix boolean serialization

### DIFF
--- a/ShikimoriSharp/Bases/ApiBase.cs
+++ b/ShikimoriSharp/Bases/ApiBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -51,7 +52,14 @@ namespace ShikimoriSharp.Bases
                 .Where(it => !(it.Value is null));
             var content = new MultipartFormDataContent();
             foreach (var i in typeEnum)
-                content.Add(new StringContent(i.Value.ToString()), i.Name);
+                if (i.Value is bool b)
+                {
+                    content.Add(new StringContent(b ? "true" : "false"));
+                }
+                else
+                {
+                    content.Add(new StringContent(i.Value.ToString()), i.Name);
+                }
 
 
             return content;

--- a/ShikimoriSharp/ShikimoriSharp.csproj
+++ b/ShikimoriSharp/ShikimoriSharp.csproj
@@ -8,13 +8,13 @@
         <Description>ShikimoriSharp is the best shikimori.one API wrapper</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/JustRoxy/ShikimoriSharp</RepositoryUrl>
-        <PackageVersion>1.3.1</PackageVersion>
+        <PackageVersion>1.3.4</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-        <PackageReference Include="Polly" Version="7.2.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Polly" Version="7.2.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #19 

The problem was that default bool.ToString() converts true -> "True", and false -> "False". Shikimori API requires it to be "true" and "false" instead. 